### PR TITLE
Add Amazon Linux support

### DIFF
--- a/SOURCES/haproxy.syslog.amzn1
+++ b/SOURCES/haproxy.syslog.amzn1
@@ -1,0 +1,11 @@
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
+
+$template HAProxy,"%syslogtag%%msg:::drop-last-lf%\n"
+$template TraditionalFormatWithPRI,"%pri-text%: %timegenerated% %syslogtag%%msg:::drop-last-lf%\n"
+
+local2.=info     /var/log/haproxy/access.log;HAProxy
+local2.=notice;local2.=warning    /var/log/haproxy/status.log;TraditionalFormatWithPRI
+local2.error    /var/log/haproxy/error.log;TraditionalFormatWithPRI
+local2.* ~

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -30,13 +30,7 @@ BuildRequires: pcre-devel make gcc openssl-devel
 
 Requires(pre):      shadow-utils
 
-%if 0%{?amzn1}
-Requires(post):     chkconfig, initscripts
-Requires(preun):    chkconfig, initscripts
-Requires(postun):   initscripts
-%endif
-
-%if 0%{?el6}
+%if 0%{?el6} || 0%{?amzn1}
 Requires(post):     chkconfig, initscripts
 Requires(preun):    chkconfig, initscripts
 Requires(postun):   initscripts
@@ -97,11 +91,7 @@ systemd_opts=
 %{__install} -d %{buildroot}%{_mandir}/man1/
 
 %{__install} -s %{name} %{buildroot}%{_sbindir}/
-%if 0%{?amzn1}
-%{__install} -d %{buildroot}%{_sysconfdir}/rc.d/init.d
-%{__install} -c -m 755 %{SOURCE2} %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
-%endif
-%if 0%{?el6}
+%if 0%{?el6} || 0%{?amzn1}
 %{__install} -d %{buildroot}%{_sysconfdir}/rc.d/init.d
 %{__install} -c -m 755 %{SOURCE2} %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
 %endif
@@ -132,12 +122,7 @@ exit 0
 systemctl restart rsyslog.service
 %endif
 
-%if 0%{?el6}
-/sbin/chkconfig --add %{name}
-/sbin/service rsyslog restart >/dev/null 2>&1 || :
-%endif
-
-%if 0%{?amzn1}
+%if 0%{?el6} || 0%{?amzn1}
 /sbin/chkconfig --add %{name}
 /sbin/service rsyslog restart >/dev/null 2>&1 || :
 %endif
@@ -147,20 +132,12 @@ systemctl restart rsyslog.service
 %systemd_preun %{name}.service
 %endif
 
-%if 0%{?el6}
+%if 0%{?el6} || 0%{?amzn1}
 if [ $1 = 0 ]; then
   /sbin/service %{name} stop >/dev/null 2>&1 || :
   /sbin/chkconfig --del %{name}
 fi
 %endif
-
-%if 0%{?amzn1}
-if [ $1 = 0 ]; then
-  /sbin/service %{name} stop >/dev/null 2>&1 || :
-  /sbin/chkconfig --del %{name}
-fi
-%endif
-
 
 %postun
 %if 0%{?el7}
@@ -168,14 +145,7 @@ fi
 systemctl restart rsyslog.service
 %endif
 
-%if 0%{?el6}
-if [ "$1" -ge "1" ]; then
-  /sbin/service %{name} condrestart >/dev/null 2>&1 || :
-  /sbin/service rsyslog restart >/dev/null 2>&1 || :
-fi
-%endif
-
-%if 0%{?amzn1}
+%if 0%{?el6} || 0%{?amzn1}
 if [ "$1" -ge "1" ]; then
   /sbin/service %{name} condrestart >/dev/null 2>&1 || :
   /sbin/service rsyslog restart >/dev/null 2>&1 || :


### PR DESCRIPTION
Amazon Linux is based on Fedora and works a lot like RHEL6, so the project just needed to be updated to work with it. There aren't any RHEL6 RPMs of HAProxy 1.8.x.