### PR TITLE
Add Lua support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 SOURCES/haproxy-*.tar.gz 
 rpmbuild
 RPMS
+lua-*

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 HOME=$(shell pwd)
 MAINVERSION=2.0
+LUA_VERSION=5.3.5
+USE_LUA?=0
 VERSION=$(shell wget -qO- http://git.haproxy.org/git/haproxy-${MAINVERSION}.git/refs/tags/ | sed -n 's:.*>\(.*\)</a>.*:\1:p' | sed 's/^.//' | sort -rV | head -1)
 ifeq ("${VERSION}","./")
         VERSION="${MAINVERSION}.0"
@@ -15,11 +17,25 @@ clean:
 	rm -f ./SOURCES/haproxy-${VERSION}.tar.gz
 	rm -rf ./rpmbuild
 	mkdir -p ./rpmbuild/SPECS/ ./rpmbuild/SOURCES/ ./rpmbuild/RPMS/ ./rpmbuild/SRPMS/
+	rm -rf ./lua-${LUA_VERSION}*
 
 download-upstream:
 	wget http://www.haproxy.org/download/${MAINVERSION}/src/haproxy-${VERSION}.tar.gz -O ./SOURCES/haproxy-${VERSION}.tar.gz
 
-build: install_prereq clean download-upstream
+build_lua:
+	wget https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz
+	tar xzf lua-${LUA_VERSION}.tar.gz
+	cd lua-${LUA_VERSION}
+	$(MAKE) -C lua-${LUA_VERSION} clean
+	$(MAKE) -C lua-${LUA_VERSION} MYCFLAGS=-fPIC linux test  # MYCFLAGS=-fPIC is required during linux ld
+	$(MAKE) -C lua-${LUA_VERSION} install
+
+build_stages := install_prereq clean download-upstream
+ifeq ($(USE_LUA),1)
+	build_stages += build_lua
+endif
+
+build: $(build_stages)
 	cp -r ./SPECS/* ./rpmbuild/SPECS/ || true
 	cp -r ./SOURCES/* ./rpmbuild/SOURCES/ || true
 	rpmbuild -ba SPECS/haproxy.spec \
@@ -29,4 +45,5 @@ build: install_prereq clean download-upstream
 	--define "_builddir %{_topdir}/BUILD" \
 	--define "_buildroot %{_topdir}/BUILDROOT" \
 	--define "_rpmdir %{_topdir}/RPMS" \
-	--define "_srcrpmdir %{_topdir}/SRPMS"
+	--define "_srcrpmdir %{_topdir}/SRPMS" \
+	--define "_use_lua %{USE_LUA}"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ Perform the following steps on a build box as a regular user.
     git checkout 2.0
 
 ## Build using makefile
+### Without Lua support
     make
-    
-Resulting RPM will be in /opt/rpm-haproxy/rpmbuild/RPMS/x86_64/
+
+### With Lua support
+    make USE_LUA=1
+
+Resulting RPM will be in `/opt/rpm-haproxy/rpmbuild/RPMS/x86_64/`
 
 ## Credits
 

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -100,7 +100,7 @@ USE_TFO=1
 USE_NS=1
 %endif
 
-%{__make} -j$RPM_BUILD_NCPUS %{?_smp_mflags} CPU="generic" TARGET="linux-glibc" ${systemd_opts} ${pcre_opts} USE_OPENSSL=1 USE_ZLIB=1 ${regparm_opts} ADDINC="%{optflags}" USE_LINUX_TPROXY=1 USE_THREAD=1 USE_TFO=${USE_TFO} USE_NS=${USE_NS} ADDLIB="%{__global_ldflags}"
+%{__make} -j$RPM_BUILD_NCPUS %{?_smp_mflags} USE_LUA=%{_use_lua} CPU="generic" TARGET="linux-glibc" ${systemd_opts} ${pcre_opts} USE_OPENSSL=1 USE_ZLIB=1 ${regparm_opts} ADDINC="%{optflags}" USE_LINUX_TPROXY=1 USE_THREAD=1 USE_TFO=${USE_TFO} USE_NS=${USE_NS} ADDLIB="%{__global_ldflags}"
 
 pushd contrib/halog
 %{__make} ${halog} OPTIMIZE="%{optflags} %{__global_ldflags}"


### PR DESCRIPTION
Add Lua support when compiling haproxy, it's useful when you need custom scripting.

Makefile part will download Lua in version `LUA_VERSION`, make test for linux and install it on compiling machine.

By default Lua is ignored

To compile with Lua run 
```bash
make USE_LUA=1
```