### PR TITLE
Remove duplicate line from systemd service file.

### DIFF
--- a/SOURCES/haproxy.service
+++ b/SOURCES/haproxy.service
@@ -5,7 +5,6 @@ After=syslog.target network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/haproxy
-EnvironmentFile=-/etc/sysconfig/haproxy
 Environment="CONFIG=/etc/haproxy/haproxy.cfg" "PIDFILE=/run/haproxy.pid" "EXTRAOPTS=-S /run/haproxy-master.sock"
 ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q $EXTRAOPTS
 ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE $EXTRAOPTS


### PR DESCRIPTION
This appears to have been introduced accidentally
at 1dc994b08eb08109ef34869a2d8eb3d37fd6de4c when updating
for 1.9.