### PR TITLE
Add Amazon Linux 2 Docker build

### DIFF
--- a/Dockerfile-amzn2
+++ b/Dockerfile-amzn2
@@ -1,0 +1,12 @@
+FROM amazonlinux:2
+
+RUN yum install -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+RUN mkdir RPMS
+RUN chmod -R 777 RPMS
+RUN mkdir SPECS
+RUN mkdir SOURCES
+COPY Makefile Makefile
+COPY SPECS/haproxy.spec SPECS/haproxy.spec
+COPY SOURCES/* SOURCES/
+
+CMD make NO_SUDO=1 && cp /rpmbuild/RPMS/x86_64/* /RPMS && cp /rpmbuild/SRPMS/* /RPMS

--- a/Dockerfile8
+++ b/Dockerfile8
@@ -1,5 +1,7 @@
 FROM centos:8
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
 RUN yum install -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
 RUN mkdir RPMS
 RUN chmod -R 777 RPMS

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,14 @@ endif
 build-docker:
 	docker build -t haproxy-rpm-builder7:${VERSION}-${RELEASE} -f Dockerfile7 .
 	docker build -t haproxy-rpm-builder8:${VERSION}-${RELEASE} -f Dockerfile8 .
+	docker build -t haproxy-rpm-builder-amzn2:${VERSION}-${RELEASE} -f Dockerfile-amzn2 .
 
 run-docker: build-docker
 	mkdir -p RPMS
 	chcon -Rt svirt_sandbox_file_t RPMS || true
 	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder7:${VERSION}-${RELEASE}
 	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder8:${VERSION}-${RELEASE}
+	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder-amzn2:${VERSION}-${RELEASE}
 
 build: $(build_stages)
 	cp -r ./SPECS/* ./rpmbuild/SPECS/ || true

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -231,6 +231,9 @@ fi
 %endif
 
 %changelog
+* Thu Feb 10 2022 Kai Parry <tp@threadproc.io>
+- Add Docker support for Amazon Linux 2
+
 * Sat May 30 2021 David Bezemer <info@davidbezemer.nl>
 - Add support for HAProxy 2.4.x
 


### PR DESCRIPTION
This PR adds a Dockerfile to build an amzn2 image, as well as adding it to the Makefile.

It also, tangentially, fixes the CentOS 8 build.

Tested w/ GitHub Actions successfully: https://github.com/threadproc/rpm-haproxy/releases/tag/WiP