### PR TITLE
Make building haproxy rpm possible in docker-almalinux9 

### DIFF
--- a/Dockerfile9
+++ b/Dockerfile9
@@ -1,0 +1,12 @@
+FROM almalinux:9.0
+
+RUN dnf install --allowerasing -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+RUN mkdir RPMS
+RUN chmod -R 777 RPMS
+RUN mkdir SPECS
+RUN mkdir SOURCES
+COPY Makefile Makefile
+COPY SPECS/haproxy.spec SPECS/haproxy.spec
+COPY SOURCES/* SOURCES/
+
+CMD make NO_SUDO=1 && cp /rpmbuild/RPMS/x86_64/* /RPMS && cp /rpmbuild/SRPMS/* /RPMS

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ endif
 build-docker:
 	docker build -t haproxy-rpm-builder7:${VERSION}-${RELEASE} -f Dockerfile7 .
 	docker build -t haproxy-rpm-builder8:${VERSION}-${RELEASE} -f Dockerfile8 .
+	docker build -t haproxy-rpm-builder9:${VERSION}-${RELEASE} -f Dockerfile9 .
 	docker build -t haproxy-rpm-builder-amzn2:${VERSION}-${RELEASE} -f Dockerfile-amzn2 .
 
 run-docker: build-docker
@@ -53,6 +54,7 @@ run-docker: build-docker
 	chcon -Rt svirt_sandbox_file_t RPMS || true
 	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder7:${VERSION}-${RELEASE}
 	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder8:${VERSION}-${RELEASE}
+	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder9:${VERSION}-${RELEASE}
 	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder-amzn2:${VERSION}-${RELEASE}
 
 build: $(build_stages)

--- a/SOURCES/haproxy.syslog.el9
+++ b/SOURCES/haproxy.syslog.el9
@@ -1,0 +1,18 @@
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
+
+$template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-last-lf%\n"
+$template HAProxyAccess,"%msg%\n"
+
+if $programname startswith 'haproxy' then {
+  if $syslogseverity == 6 then
+      action(type="omfile" file="/var/log/haproxy/access.log" template="HAProxyAccess")
+      stop
+  if $syslogseverity <= 3 then
+      action(type="omfile" file="/var/log/haproxy/error.log" template="HAProxy")
+      stop
+  if $syslogseverity <= 5 then
+      action(type="omfile" file="/var/log/haproxy/status.log" template="HAProxy")
+      stop
+}

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -231,7 +231,7 @@ fi
 %endif
 
 %changelog
-* Thu Feb 10 2022 Karsten Horsmann <khorsmann@gmail.com>
+* Thu Jul 07 2022 Karsten Horsmann <khorsmann@gmail.com>
 - Add Docker support for RHEL 9.0 / Almalinux 9.0
 
 * Thu Feb 10 2022 Kai Parry <tp@threadproc.io>

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -46,7 +46,7 @@ Requires(preun):    chkconfig, initscripts
 Requires(postun):   initscripts
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
 BuildRequires:      systemd-units
 BuildRequires:      systemd-devel
 Requires(post):     systemd
@@ -91,12 +91,12 @@ CFLAGS="%{optflags}"
 USE_TFO=
 USE_NS=
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
 systemd_opts="USE_SYSTEMD=1"
 pcre_opts="USE_PCRE=1 USE_PCRE_JIT=1"
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn1} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn1} || 0%{?el8} || 0%{?el9}
 USE_TFO=1
 USE_NS=1
 %endif
@@ -152,7 +152,7 @@ USE_PROMETHEUS="USE_PROMEX=1"
 %{__install} -c -m 755 %{SOURCE2} %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
 %{__install} -s %{name} %{buildroot}%{_sbindir}/
 %{__install} -p -D -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 %endif
@@ -169,7 +169,7 @@ getent passwd %{haproxy_user} >/dev/null || \
 exit 0
 
 %post
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
 %systemd_post %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -180,7 +180,7 @@ systemctl reload-or-try-restart rsyslog.service
 %endif
 
 %preun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
 %systemd_preun %{name}.service
 %endif
 
@@ -192,7 +192,7 @@ fi
 %endif
 
 %postun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
 %systemd_postun_with_restart %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -207,7 +207,7 @@ fi
 %files
 %defattr(-,root,root)
 %doc CHANGELOG README examples/*.cfg doc/architecture.txt doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
     %license LICENSE
 %endif
 %doc %{_mandir}/man1/*
@@ -226,11 +226,14 @@ fi
 %attr(0755,root,root) %config %_sysconfdir/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
 %attr(-,root,root) %{_unitdir}/%{name}.service
 %endif
 
 %changelog
+* Thu Feb 10 2022 Karsten Horsmann <khorsmann@gmail.com>
+- Add Docker support for RHEL 9.0 / Almalinux 9.0
+
 * Thu Feb 10 2022 Kai Parry <tp@threadproc.io>
 - Add Docker support for Amazon Linux 2
 


### PR DESCRIPTION
so its compatible with RHEL 9. Fixes also Issue #49