### PR TITLE
Fix wrong log routing on EL7

### DIFF
--- a/SOURCES/haproxy.syslog.el7
+++ b/SOURCES/haproxy.syslog.el7
@@ -5,14 +5,17 @@ $UDPServerRun 514
 $template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-last-lf%\n"
 $template HAProxyAccess,"%msg%\n"
 
-if $programname startswith 'haproxy' then {
-  if $syslogseverity == 6 then
-      action(type="omfile" file="/var/log/haproxy/access.log" template="HAProxyAccess")
-      stop
-  if $syslogseverity <= 3 then
-      action(type="omfile" file="/var/log/haproxy/error.log" template="HAProxy")
-      stop
-  if $syslogseverity <= 5 then
-      action(type="omfile" file="/var/log/haproxy/status.log" template="HAProxy")
-      stop
+if ($programname startswith 'haproxy' and $inputname == 'imudp') then {
+    if $syslogseverity == 6 then {
+        action(type="omfile" file="/var/log/haproxy/access.log" template="HAProxyAccess")
+        stop 
+    }
+    if $syslogseverity <= 3 then {
+        action(type="omfile" file="/var/log/haproxy/error.log" template="HAProxy")
+        stop
+    }
+    if $syslogseverity <= 5 then {
+        action(type="omfile" file="/var/log/haproxy/status.log" template="HAProxy")
+        stop
+    }
 }


### PR DESCRIPTION
* Avoid haproxy logs that are echoed from systemd-journal (errors getting send again as severity 6) by limiting source to UDP input
* Correct scoping to avoid unreachable code due to stop, and errors not logged to correct log
* Fix indentation