### PR TITLE
Transitions to OpenSSL 1.1

### DIFF
--- a/Dockerfile-amzn2
+++ b/Dockerfile-amzn2
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-RUN yum install -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+RUN yum install -y pcre-devel make gcc openssl11-devel rpm-build systemd-devel curl sed zlib-devel
 RUN mkdir RPMS
 RUN chmod -R 777 RPMS
 RUN mkdir SPECS

--- a/Dockerfile7
+++ b/Dockerfile7
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum install -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+RUN yum install -y pcre-devel make gcc openssl11-devel rpm-build systemd-devel curl sed zlib-devel
 RUN mkdir RPMS
 RUN chmod -R 777 RPMS
 RUN mkdir SPECS

--- a/Dockerfile8
+++ b/Dockerfile8
@@ -2,7 +2,7 @@ FROM centos:8
 
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
-RUN yum install -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+RUN yum install -y pcre-devel make gcc openssl11-devel rpm-build systemd-devel curl sed zlib-devel
 RUN mkdir RPMS
 RUN chmod -R 777 RPMS
 RUN mkdir SPECS

--- a/Dockerfile9
+++ b/Dockerfile9
@@ -1,6 +1,6 @@
 FROM almalinux:9.0
 
-RUN dnf install --allowerasing -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+RUN dnf install --allowerasing -y pcre-devel make gcc openssl11-devel rpm-build systemd-devel curl sed zlib-devel
 RUN mkdir RPMS
 RUN chmod -R 777 RPMS
 RUN mkdir SPECS

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ all: build
 
 install_prereq:
 ifeq ($(NO_SUDO),1)
-	yum install -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+	yum install -y pcre-devel make gcc openssl11-devel rpm-build systemd-devel curl sed zlib-devel
 else
-	sudo yum install -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+	sudo yum install -y pcre-devel make gcc openssl11-devel rpm-build systemd-devel curl sed zlib-devel
 endif
 
 clean:
@@ -54,7 +54,7 @@ run-docker: build-docker
 	chcon -Rt svirt_sandbox_file_t RPMS || true
 	docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder7:${VERSION}-${RELEASE}
 	docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder8:${VERSION}-${RELEASE}
-  docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder9:${VERSION}-${RELEASE}
+	docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder9:${VERSION}-${RELEASE}
 	docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder-amzn2:${VERSION}-${RELEASE}
 
 build: $(build_stages)

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -34,8 +34,8 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-root
 BuildRequires: pcre-devel
 BuildRequires: zlib-devel
 BuildRequires: make
-BuildRequires: gcc openssl-devel
-BuildRequires: openssl-devel
+BuildRequires: gcc openssl11-devel
+BuildRequires: openssl11-devel
 
 Requires(pre):      shadow-utils
 Requires:           rsyslog


### PR DESCRIPTION
I updated for OpenSSL 1.1 because my organization needs newer support in HAProxy. Amazon Linux 2 and CentOS 7 have an alternate spot use packages available, but I'm not sure about other distributions. How would you approach offering the option to choose OpenSSL 1.0 or OpenSSL 1.1?

I should mention that the resulting RPM runs as expected and offers the latest OpenSSL features.