### PR TITLE
Add support for Amazon Linux 2023

### DIFF
--- a/Dockerfile-amzn2023
+++ b/Dockerfile-amzn2023
@@ -1,4 +1,4 @@
-FROM almalinux:9.0
+FROM amazonlinux:2023
 
 RUN dnf install --allowerasing -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
 RUN mkdir RPMS

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ build-docker:
 	docker build -t haproxy-rpm-builder8:${VERSION}-${RELEASE} -f Dockerfile8 .
 	docker build -t haproxy-rpm-builder9:${VERSION}-${RELEASE} -f Dockerfile9 .
 	docker build -t haproxy-rpm-builder-amzn2:${VERSION}-${RELEASE} -f Dockerfile-amzn2 .
+	docker build -t haproxy-rpm-builder-amzn2023:${VERSION}-${RELEASE} -f Dockerfile-amzn2023 .
 
 run-docker: build-docker
 	mkdir -p RPMS
@@ -56,6 +57,7 @@ run-docker: build-docker
 	docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder8:${VERSION}-${RELEASE}
 	docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder9:${VERSION}-${RELEASE}
 	docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder-amzn2:${VERSION}-${RELEASE}
+	docker run --volume $(HOME)/RPMS:/RPMS --rm -e USE_PROMETHEUS=${USE_PROMETHEUS} -e RELEASE=${RELEASE} haproxy-rpm-builder-amzn2023:${VERSION}-${RELEASE}
 
 build: $(build_stages)
 	cp -r ./SPECS/* ./rpmbuild/SPECS/ || true

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,9 @@ endif
 	$(MAKE) -C lua-${LUA_VERSION} clean
 ifeq ($(NO_SUDO),1)
 	$(MAKE) -C lua-${LUA_VERSION} MYCFLAGS=-fPIC linux test  # MYCFLAGS=-fPIC is required during linux ld
-else
-	sudo $(MAKE) -C lua-${LUA_VERSION} MYCFLAGS=-fPIC linux test  # MYCFLAGS=-fPIC is required during linux ld
-endif
-ifeq ($(NO_SUDO),1)
 	$(MAKE) -C lua-${LUA_VERSION} install
 else
+	sudo $(MAKE) -C lua-${LUA_VERSION} MYCFLAGS=-fPIC linux test  # MYCFLAGS=-fPIC is required during linux ld
 	sudo $(MAKE) -C lua-${LUA_VERSION} install
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,25 @@ download-upstream:
 	curl -o  ./SOURCES/haproxy-${VERSION}.tar.gz http://www.haproxy.org/download/${MAINVERSION}/src/haproxy-${VERSION}.tar.gz
 
 build_lua:
+ifeq ($(NO_SUDO),1)
+	yum install -y readline-devel
+else
 	sudo yum install -y readline-devel
+endif
 	curl -O https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz
 	tar xzf lua-${LUA_VERSION}.tar.gz
 	cd lua-${LUA_VERSION}
 	$(MAKE) -C lua-${LUA_VERSION} clean
+ifeq ($(NO_SUDO),1)
 	$(MAKE) -C lua-${LUA_VERSION} MYCFLAGS=-fPIC linux test  # MYCFLAGS=-fPIC is required during linux ld
+else
+	sudo $(MAKE) -C lua-${LUA_VERSION} MYCFLAGS=-fPIC linux test  # MYCFLAGS=-fPIC is required during linux ld
+endif
+ifeq ($(NO_SUDO),1)
 	$(MAKE) -C lua-${LUA_VERSION} install
+else
+	sudo $(MAKE) -C lua-${LUA_VERSION} install
+endif
 
 build_stages := install_prereq clean download-upstream
 ifeq ($(USE_LUA),1)

--- a/SOURCES/haproxy.syslog.amzn2023
+++ b/SOURCES/haproxy.syslog.amzn2023
@@ -1,0 +1,13 @@
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
+$MaxMessageSize 64k
+$FileCreateMode 0600
+
+$template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg%\n"
+$template HAProxyAccess,"%msg%\n"
+
+local2.=info     /var/log/haproxy/access.log;HAProxyAccess
+local2.error    /var/log/haproxy/error.log;HAProxy
+local2.* /var/log/haproxy/status.log
+& ~

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -54,6 +54,13 @@ Requires(preun):    systemd
 Requires(postun):   systemd
 %endif
 
+%if 0%{?amzn2023}
+BuildRequires:      systemd-devel
+Requires(post):     systemd
+Requires(preun):    systemd
+Requires(postun):   systemd
+%endif
+
 %description
 HA-Proxy is a TCP/HTTP reverse proxy which is particularly suited for high
 availability environments. Indeed, it can:
@@ -91,12 +98,12 @@ CFLAGS="%{optflags}"
 USE_TFO=
 USE_NS=
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
 systemd_opts="USE_SYSTEMD=1"
 pcre_opts="USE_PCRE=1 USE_PCRE_JIT=1"
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn1} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?amzn1} || 0%{?el8} || 0%{?el9}
 USE_TFO=1
 USE_NS=1
 %endif
@@ -152,7 +159,7 @@ USE_PROMEX="USE_PROMEX=1"
 %{__install} -c -m 755 %{SOURCE2} %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
 %{__install} -s %{name} %{buildroot}%{_sbindir}/
 %{__install} -p -D -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 %endif
@@ -169,7 +176,7 @@ getent passwd %{haproxy_user} >/dev/null || \
 exit 0
 
 %post
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
 %systemd_post %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -180,7 +187,7 @@ systemctl reload-or-try-restart rsyslog.service
 %endif
 
 %preun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
 %systemd_preun %{name}.service
 %endif
 
@@ -192,7 +199,7 @@ fi
 %endif
 
 %postun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
 %systemd_postun_with_restart %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -207,7 +214,7 @@ fi
 %files
 %defattr(-,root,root)
 %doc CHANGELOG README examples/*.cfg doc/architecture.txt doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
     %license LICENSE
 %endif
 %doc %{_mandir}/man1/*
@@ -226,18 +233,21 @@ fi
 %attr(0755,root,root) %config %_sysconfdir/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8} || 0%{?el9}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
 %attr(-,root,root) %{_unitdir}/%{name}.service
 %endif
 
 %changelog
+* Wed Apr 5 2023 Xiao Liang <izzyliang@gmail.com>
+- Add support for Amazon Linux 2023
+
 * Thu Jul 07 2022 Karsten Horsmann <khorsmann@gmail.com>
 - Add Docker support for RHEL 9.0 / Almalinux 9.0
 
 * Thu Feb 10 2022 Kai Parry <tp@threadproc.io>
 - Add Docker support for Amazon Linux 2
 
-* Sat May 30 2021 David Bezemer <info@davidbezemer.nl>
+* Sun May 30 2021 David Bezemer <info@davidbezemer.nl>
 - Add support for HAProxy 2.4.x
 
 * Sun Apr 11 2021 David Bezemer <info@davidbezemer.nl>

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -34,7 +34,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-root
 BuildRequires: pcre-devel
 BuildRequires: zlib-devel
 BuildRequires: make
-BuildRequires: gcc openssl-devel
+BuildRequires: gcc
 BuildRequires: openssl-devel
 
 Requires(pre):      shadow-utils


### PR DESCRIPTION
* Add support for building RPMs on Amazon Linux 2023 (previously known as Amazon Linux 2022).
* Fixes some minor issues