### PR TITLE
Add support for Amazon Linux 2023 to HAProxy 2.2

### DIFF
--- a/Dockerfile-amzn2023
+++ b/Dockerfile-amzn2023
@@ -1,0 +1,12 @@
+FROM amazonlinux:2023
+
+RUN yum dnf install --allowerasing -y pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+RUN mkdir RPMS
+RUN chmod -R 777 RPMS
+RUN mkdir SPECS
+RUN mkdir SOURCES
+COPY Makefile Makefile
+COPY SPECS/haproxy.spec SPECS/haproxy.spec
+COPY SOURCES/* SOURCES/
+
+CMD make NO_SUDO=1 && cp /rpmbuild/RPMS/x86_64/* /RPMS && cp /rpmbuild/SRPMS/* /RPMS

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,22 @@ download-upstream:
 	curl -o  ./SOURCES/haproxy-${VERSION}.tar.gz http://www.haproxy.org/download/${MAINVERSION}/src/haproxy-${VERSION}.tar.gz
 
 build_lua:
+ifeq ($(NO_SUDO),1)
+	yum install -y readline-devel
+else
 	sudo yum install -y readline-devel
+endif
 	curl -O https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz
 	tar xzf lua-${LUA_VERSION}.tar.gz
 	cd lua-${LUA_VERSION}
 	$(MAKE) -C lua-${LUA_VERSION} clean
+ifeq ($(NO_SUDO),1)
 	$(MAKE) -C lua-${LUA_VERSION} MYCFLAGS=-fPIC linux test  # MYCFLAGS=-fPIC is required during linux ld
 	$(MAKE) -C lua-${LUA_VERSION} install
+else
+	sudo $(MAKE) -C lua-${LUA_VERSION} MYCFLAGS=-fPIC linux test  # MYCFLAGS=-fPIC is required during linux ld
+	sudo $(MAKE) -C lua-${LUA_VERSION} install
+endif
 
 build_stages := install_prereq clean download-upstream
 ifeq ($(USE_LUA),1)
@@ -46,12 +55,14 @@ endif
 build-docker:
 	docker build -t haproxy-rpm-builder7:${VERSION}-${RELEASE} -f Dockerfile7 .
 	docker build -t haproxy-rpm-builder8:${VERSION}-${RELEASE} -f Dockerfile8 .
+	docker build -t haproxy-rpm-builder-amzn2023:${VERSION}-${RELEASE} -f Dockerfile-amzn2023 .
 
 run-docker: build-docker
 	mkdir -p RPMS
 	chcon -Rt svirt_sandbox_file_t RPMS || true
 	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder7:${VERSION}-${RELEASE}
 	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder8:${VERSION}-${RELEASE}
+	docker run --volume $(HOME)/RPMS:/RPMS --rm haproxy-rpm-builder-amzn2023:${VERSION}-${RELEASE}
 
 build: $(build_stages)
 	cp -r ./SPECS/* ./rpmbuild/SPECS/ || true

--- a/SOURCES/haproxy.syslog.amzn2023
+++ b/SOURCES/haproxy.syslog.amzn2023
@@ -1,0 +1,13 @@
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
+$MaxMessageSize 64k
+$FileCreateMode 0600
+
+$template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg%\n"
+$template HAProxyAccess,"%msg%\n"
+
+local2.=info     /var/log/haproxy/access.log;HAProxyAccess
+local2.error    /var/log/haproxy/error.log;HAProxy
+local2.* /var/log/haproxy/status.log
+& ~

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -54,6 +54,13 @@ Requires(preun):    systemd
 Requires(postun):   systemd
 %endif
 
+%if 0%{?amzn2023}
+BuildRequires:      systemd-devel
+Requires(post):     systemd
+Requires(preun):    systemd
+Requires(postun):   systemd
+%endif
+
 %description
 HA-Proxy is a TCP/HTTP reverse proxy which is particularly suited for high
 availability environments. Indeed, it can:
@@ -91,12 +98,12 @@ CFLAGS="%{optflags}"
 USE_TFO=
 USE_NS=
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8}
 systemd_opts="USE_SYSTEMD=1"
 pcre_opts="USE_PCRE=1 USE_PCRE_JIT=1"
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn1} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?amzn1} || 0%{?el8}
 USE_TFO=1
 USE_NS=1
 %endif
@@ -153,7 +160,7 @@ popd
 %{__install} -c -m 755 %{SOURCE2} %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8}
 %{__install} -s %{name} %{buildroot}%{_sbindir}/
 %{__install} -p -D -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 %endif
@@ -170,7 +177,7 @@ getent passwd %{haproxy_user} >/dev/null || \
 exit 0
 
 %post
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8}
 %systemd_post %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -181,7 +188,7 @@ systemctl reload-or-try-restart rsyslog.service
 %endif
 
 %preun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8}
 %systemd_preun %{name}.service
 %endif
 
@@ -193,7 +200,7 @@ fi
 %endif
 
 %postun
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8}
 %systemd_postun_with_restart %{name}.service
 systemctl reload-or-try-restart rsyslog.service
 %endif
@@ -208,7 +215,7 @@ fi
 %files
 %defattr(-,root,root)
 %doc CHANGELOG README examples/*.cfg doc/architecture.txt doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8}
     %license LICENSE
 %endif
 %doc %{_mandir}/man1/*
@@ -226,11 +233,14 @@ fi
 %attr(0755,root,root) %config %_sysconfdir/rc.d/init.d/%{name}
 %endif
 
-%if 0%{?el7} || 0%{?amzn2} || 0%{?el8}
+%if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8}
 %attr(-,root,root) %{_unitdir}/%{name}.service
 %endif
 
 %changelog
+* Sun Apr 9 2023 Xiao Liang <izzyliang@gmail.com>
+- Add support for Amazon Linux 2023
+
 * Sun Jul 12 2020 David Bezemer <info@davidbezemer.nl>
 - Backwards compatible conditional restart using reload-or-try-restart
 


### PR DESCRIPTION
Like #60, but for making it possible to build RPMs for HAProxy 2.2 on Amazon Linux 2023