### PR TITLE
Fix dnf installation, allow passing in CPU flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ else
 endif
 
 HAS_DNF:=$(shell command -v dnf 2> /dev/null)
-ifndef HAS_DNF
-	PACKAGE_MANAGER=yum
-	INSTALL_FLAGS=-y
-else
+ifdef HAS_DNF
 	PACKAGE_MANAGER=dnf
 	INSTALL_FLAGS=-y --allowerasing
+else
+	PACKAGE_MANAGER=yum
+	INSTALL_FLAGS=-y
 endif
 
 ifeq ($(USE_PODMAN),1)

--- a/README.md
+++ b/README.md
@@ -37,13 +37,16 @@ Perform the following steps on a build box as a regular user.
 ### With Prometheus Module support
     make USE_PROMETHEUS=1
 
-### Without sudo for yum (for building in Docker)
+### Without `sudo` for `yum` (for building in Docker)
     make NO_SUDO=1
 
 ### With a custom release iteration, e.g. '2' (default '1'):
     make RELEASE=2
 
-### Custom CFLAGS, e.g. '-O0' to disable optimization for debug:
+### With a custom target `CPU`, e.g. `armv81`
+    make CPU=armv81
+
+### Custom `CFLAGS`, e.g. '-O0' to disable optimization for debug:
     make EXTRA_CFLAGS=-O0
 
 Resulting RPMs will be in `/opt/rpm-haproxy/rpmbuild/RPMS/x86_64/`

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -120,7 +120,12 @@ USE_PROMEX="USE_PROMEX=1"
   CFLAGS="$CFLAGS %{_extra_cflags}"
 %endif
 
-%{__make} -j$RPM_BUILD_NCPUS %{?_smp_mflags} ${USE_LUA} CPU="generic" TARGET="linux-glibc" ${systemd_opts} ${pcre_opts} USE_OPENSSL=1 USE_ZLIB=1 ${regparm_opts} ADDINC="$CFLAGS" USE_LINUX_TPROXY=1 USE_THREAD=1 USE_TFO=${USE_TFO} USE_NS=${USE_NS} ${USE_PROMEX} ADDLIB="%{__global_ldflags}"
+CPU="generic"
+%if "%{_cpu}" != "0"
+  CPU="%{_cpu}"
+%endif
+
+%{__make} -j$RPM_BUILD_NCPUS %{?_smp_mflags} ${USE_LUA} CPU="${CPU}" TARGET="linux-glibc" ${systemd_opts} ${pcre_opts} USE_OPENSSL=1 USE_ZLIB=1 ${regparm_opts} ADDINC="$CFLAGS" USE_LINUX_TPROXY=1 USE_THREAD=1 USE_TFO=${USE_TFO} USE_NS=${USE_NS} ${USE_PROMEX} ADDLIB="%{__global_ldflags}"
 
 %{__make} admin/halog/halog OPTIMIZE="%{optflags} %{__global_ldflags}"
 


### PR DESCRIPTION
1. When running `NO_SUDO=1 make` on systems with `dnf` (like Amazon Linux 2023), running command `yum install -y curl` might result in the following error:
```
Error:
 Problem: problem with installed package curl-minimal-8.0.1-1.amzn2023.aarch64
  - package curl-minimal-8.0.1-1.amzn2023.aarch64 conflicts with curl provided by curl-7.87.0-2.amzn2023.0.2.aarch64
  - package curl-minimal-7.88.0-1.amzn2023.0.1.aarch64 conflicts with curl provided by curl-7.87.0-2.amzn2023.0.2.aarch64
  - package curl-minimal-7.87.0-2.amzn2023.0.2.aarch64 conflicts with curl provided by curl-7.87.0-2.amzn2023.0.2.aarch64
  - package curl-minimal-7.88.1-1.amzn2023.0.1.aarch64 conflicts with curl provided by curl-7.87.0-2.amzn2023.0.2.aarch64
  - conflicting requests
  - package curl-minimal-8.0.1-1.amzn2023.aarch64 conflicts with curl provided by curl-7.88.0-1.amzn2023.0.1.aarch64
  - package curl-minimal-7.88.0-1.amzn2023.0.1.aarch64 conflicts with curl provided by curl-7.88.0-1.amzn2023.0.1.aarch64
  - package curl-minimal-7.87.0-2.amzn2023.0.2.aarch64 conflicts with curl provided by curl-7.88.0-1.amzn2023.0.1.aarch64
  - package curl-minimal-7.88.1-1.amzn2023.0.1.aarch64 conflicts with curl provided by curl-7.88.0-1.amzn2023.0.1.aarch64
  - package curl-minimal-8.0.1-1.amzn2023.aarch64 conflicts with curl provided by curl-7.88.1-1.amzn2023.0.1.aarch64
  - package curl-minimal-7.88.0-1.amzn2023.0.1.aarch64 conflicts with curl provided by curl-7.88.1-1.amzn2023.0.1.aarch64
  - package curl-minimal-7.87.0-2.amzn2023.0.2.aarch64 conflicts with curl provided by curl-7.88.1-1.amzn2023.0.1.aarch64
  - package curl-minimal-7.88.1-1.amzn2023.0.1.aarch64 conflicts with curl provided by curl-7.88.1-1.amzn2023.0.1.aarch64
  - package curl-minimal-8.0.1-1.amzn2023.aarch64 conflicts with curl provided by curl-8.0.1-1.amzn2023.aarch64
  - package curl-minimal-7.88.0-1.amzn2023.0.1.aarch64 conflicts with curl provided by curl-8.0.1-1.amzn2023.aarch64
  - package curl-minimal-7.87.0-2.amzn2023.0.2.aarch64 conflicts with curl provided by curl-8.0.1-1.amzn2023.aarch64
  - package curl-minimal-7.88.1-1.amzn2023.0.1.aarch64 conflicts with curl provided by curl-8.0.1-1.amzn2023.aarch64
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
```


Fix this issue by checking for `dnf` binary and pass in `--allowerasing` when it is detected


2. Allow user to pass in `CPU` flag for building `haproxy`, and defaults it to `generic`
    * Per Amazon's Getting started guide on Graviton, building `haproxy` with `CPU=armv81` "improves HAProxy performance by 4x": https://github.com/aws/aws-graviton-getting-started#recent-software-updates-relevant-to-graviton