### PR TITLE
Fixes two issues with make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install_prereq:
 		$(SUDO) yum install -y $(PREREQ)
 
 clean:
-	rm -f ./SOURCES/haproxy-${VERSION}.tar.gz
+	rm -f ./SOURCES/haproxy-*.tar.gz
 	rm -rf ./rpmbuild
 	mkdir -p ./rpmbuild/SPECS/ ./rpmbuild/SOURCES/ ./rpmbuild/RPMS/ ./rpmbuild/SRPMS/
 	rm -rf ./lua-${LUA_VERSION}*


### PR DESCRIPTION
Yesterday, I built haproxy 2.8.5 using `make MAINVERSION=2.8`, which downloaded `haproxy-2.8.5.tar.gz` into `./SOURCES`. Today, 2.8.6 was released so I wanted to build it, but start fresh. I issued `make clean`, but the code tried to remove `haproxy-2.4.25.tar.gz` which was obviously incorrect, *and* the `haproxy-2.8.5.tar.gz` file remained. `make clean MAINVERSION=2.8` did not work either, because it wants to remove `haproxy-2.8.6.tar.gz` (the current upstream version) and nothing else. 

The way `make clean` is configured now, it will only try to remove whatever the current upstream version of `MAINVERSION` is rather than removing any/all versions which might happen to be in `./SOURCES`. This could also get messy for people who might be using the same build box for multiple `MAINVERSION` versions, say `2.7` and `2.8`. 

Therefore, for `make clean` to work as I would expect it to, I propose we remove all `./SOURCES/haproxy-*.tar.gz` archives.

Lastly, the git diff is showing I removed the last line feed from EOF but I didn't - it's still there in code. I am not sure why git is reporting it as a change; I tried to put the line feed back, but just got an empty commit `a364d0f`. 🙄 Apologies for the mess.