### PR TITLE
Fix build errors post HAProxy 3.2

### DIFF
--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -216,16 +216,9 @@ if [ "$1" -ge "1" ]; then
 fi
 %endif
 
-# The file "README" is available < 3.2, while "README.md" is available >= 3.2; if we cannot find either, don't include such file
-%define _readme_file %([ -f README ] && echo README || [ -f README.md ] && echo README.md || echo '')
-
-# The file "doc/architecture.txt" is only available pre 3.2, do not include if the file does not exist
-%define _architecture_txt %([ -f doc/architecture.txt ] && echo doc/architecture.txt || echo '')
-
-%define _doc_files CHANGELOG %{_readme_file} examples/*.cfg %{_architecture_txt} doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
 %files
 %defattr(-,root,root)
-%doc %{?_doc_files}
+%doc CHANGELOG README* examples/*.cfg doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
 %if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
     %license LICENSE
 %endif

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -216,9 +216,13 @@ if [ "$1" -ge "1" ]; then
 fi
 %endif
 
-# The file "README" is available pre 3.2 while "README.md" is available after that; if we cannot find either, don't include such
-# "doc/architecture.txt" is only available pre 3.2, do not include if the file does not exist
-%define _doc_files CHANGELOG %([ -f README ] && echo README || [ -f README.md ] && echo README.md || echo '') examples/*.cfg %([ -f doc/architecture.txt ] && echo doc/architecture.txt || echo '') doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
+# The file "README" is available < 3.2, while "README.md" is available >= 3.2; if we cannot find either, don't include such file
+%define _readme_file %([ -f README ] && echo README || [ -f README.md ] && echo README.md || echo '')
+
+# The file "doc/architecture.txt" is only available pre 3.2, do not include if the file does not exist
+%define _architecture_txt %([ -f doc/architecture.txt ] && echo doc/architecture.txt || echo '')
+
+%define _doc_files CHANGELOG %{_readme_file} examples/*.cfg %{_architecture_txt} doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
 %files
 %defattr(-,root,root)
 %doc %{?_doc_files}

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -216,9 +216,12 @@ if [ "$1" -ge "1" ]; then
 fi
 %endif
 
+# The file "README" is available pre 3.2 while "README.md" is available after that; if we cannot find either, don't include such
+# "doc/architecture.txt" is only available pre 3.2, do not include if the file does not exist
+%define _doc_files CHANGELOG %([ -f README ] && echo README || [ -f README.md ] && echo README.md || echo '') examples/*.cfg %([ -f doc/architecture.txt ] && echo doc/architecture.txt || echo '') doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
 %files
 %defattr(-,root,root)
-%doc CHANGELOG README examples/*.cfg doc/architecture.txt doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
+%doc %{?_doc_files}
 %if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
     %license LICENSE
 %endif


### PR DESCRIPTION
Fixes #71 

`doc/architecture.txt` was removed in https://github.com/haproxy/haproxy/commit/95b9d8abeed64d2262206e4ffdef87f274b20f2f

Per commit message:
> It's totally outdated (last updated 18 years ago, when laptop processors were still 32 bits), mentions keywords and external products that don't exist anymore. It's not even on docs.haproxy.org.

Don't think we should keep this outdated doc in the final product.


For `README`/`README.md`, using a `README*` make things work on all cases.


# Verification:
```
podman run -it --rm -v $PWD:/root -w /root --name al2023 amazonlinux:2023 bash
...
bash-5.2# make NO_SUDO=1 MAINVERSION=3.0
# Check if the prereqs are there before trying to sudo
rpm -q pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel || \
   dnf install -y --allowerasing pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
pcre-devel-8.44-3.amzn2023.1.0.3.aarch64
make-4.3-5.amzn2023.0.2.aarch64
gcc-11.5.0-5.amzn2023.0.5.aarch64
openssl-devel-3.2.2-1.amzn2023.0.2.aarch64
rpm-build-4.16.1.3-29.amzn2023.0.6.aarch64
systemd-devel-252.23-10.amzn2023.aarch64
curl-8.11.1-4.amzn2023.0.3.aarch64
sed-4.8-7.amzn2023.0.2.aarch64
zlib-devel-1.2.11-33.amzn2023.0.5.aarch64
rm -f ./SOURCES/haproxy-*.tar.gz
rm -rf ./SOURCES/lua-*
rm -rf ./rpmbuild
mkdir -p ./rpmbuild/SPECS/ ./rpmbuild/SOURCES/ ./rpmbuild/RPMS/ ./rpmbuild/SRPMS/
curl -o ./SOURCES/haproxy-3.0.14.tar.gz http://www.haproxy.org/download/3.0/src/haproxy-3.0.14.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 4643k  100 4643k    0     0  2341k      0  0:00:01  0:00:01 --:--:-- 2341k
cp -r ./SPECS/* ./rpmbuild/SPECS/ || true
cp -r ./SOURCES/* ./rpmbuild/SOURCES/ || true
rpmbuild -ba SPECS/haproxy.spec \
--define "mainversion 3.0" \
--define "version 3.0.14" \
--define "release 1" \
--define "_cpu 0" \
--define "_extra_cflags 0" \
--define "_topdir %(pwd)/rpmbuild" \
--define "_builddir %{_topdir}/BUILD" \
--define "_buildroot %{_topdir}/BUILDROOT" \
--define "_rpmdir %{_topdir}/RPMS" \
--define "_srcrpmdir %{_topdir}/SRPMS" \
--define "_use_lua 0" \
--define "_use_prometheus 0"
setting SOURCE_DATE_EPOCH=1690243200
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.eOVTC0
...
Executing(%doc): /bin/sh -e /var/tmp/rpm-tmp.QerVbZ
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd haproxy-3.0.14
+ DOCDIR=/root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
+ export LC_ALL=C
+ LC_ALL=C
+ export DOCDIR
+ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr CHANGELOG /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
***** + cp -pr README /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr examples/basic-config-edge.cfg examples/content-sw-sample.cfg examples/option-http_proxy.cfg examples/quick-test.cfg examples/socks4.cfg examples/transparent_proxy.cfg examples/wurfl-example.cfg /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr doc/configuration.txt /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr doc/intro.txt /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr doc/management.txt /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr doc/proxy-protocol.txt /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64/usr/share/doc/haproxy
+ RPM_EC=0
++ jobs -p
+ exit 0
...
+ exit 0
bash-5.2# make NO_SUDO=1 MAINVERSION=3.3
# Check if the prereqs are there before trying to sudo
rpm -q pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel || \
	 dnf install -y --allowerasing pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
pcre-devel-8.44-3.amzn2023.1.0.3.aarch64
make-4.3-5.amzn2023.0.2.aarch64
gcc-11.5.0-5.amzn2023.0.5.aarch64
openssl-devel-3.2.2-1.amzn2023.0.2.aarch64
rpm-build-4.16.1.3-29.amzn2023.0.6.aarch64
systemd-devel-252.23-10.amzn2023.aarch64
curl-8.11.1-4.amzn2023.0.3.aarch64
sed-4.8-7.amzn2023.0.2.aarch64
zlib-devel-1.2.11-33.amzn2023.0.5.aarch64
rm -f ./SOURCES/haproxy-*.tar.gz
rm -rf ./SOURCES/lua-*
rm -rf ./rpmbuild
mkdir -p ./rpmbuild/SPECS/ ./rpmbuild/SOURCES/ ./rpmbuild/RPMS/ ./rpmbuild/SRPMS/
curl -o ./SOURCES/haproxy-3.3.1.tar.gz http://www.haproxy.org/download/3.3/src/haproxy-3.3.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 5119k  100 5119k    0     0  2551k      0  0:00:02  0:00:02 --:--:-- 2551k
cp -r ./SPECS/* ./rpmbuild/SPECS/ || true
cp -r ./SOURCES/* ./rpmbuild/SOURCES/ || true
rpmbuild -ba SPECS/haproxy.spec \
--define "mainversion 3.3" \
--define "version 3.3.1" \
--define "release 1" \
--define "_cpu 0" \
--define "_extra_cflags 0" \
--define "_topdir %(pwd)/rpmbuild" \
--define "_builddir %{_topdir}/BUILD" \
--define "_buildroot %{_topdir}/BUILDROOT" \
--define "_rpmdir %{_topdir}/RPMS" \
--define "_srcrpmdir %{_topdir}/SRPMS" \
--define "_use_lua 0" \
--define "_use_prometheus 0"
setting SOURCE_DATE_EPOCH=1690243200
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.SulgJq
...
Executing(%doc): /bin/sh -e /var/tmp/rpm-tmp.TOC4M2
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd haproxy-3.3.1
+ DOCDIR=/root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
+ export LC_ALL=C
+ LC_ALL=C
+ export DOCDIR
+ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr CHANGELOG /root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
***** + cp -pr README.md /root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr examples/basic-config-edge.cfg examples/content-sw-sample.cfg examples/games.cfg examples/mptcp.cfg examples/option-http_proxy.cfg examples/quick-test.cfg examples/socks4.cfg examples/traces.cfg examples/transparent_proxy.cfg examples/wurfl-example.cfg /root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr doc/configuration.txt /root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr doc/intro.txt /root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr doc/management.txt /root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
+ cp -pr doc/proxy-protocol.txt /root/rpmbuild/BUILDROOT/haproxy-3.3.1-1.amzn2023.aarch64/usr/share/doc/haproxy
+ RPM_EC=0
++ jobs -p
...
+ exit 0
bash-5.2#

```