### PR TITLE
Add support for AWS LC [#74]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ NO_SUDO?=0
 USE_PODMAN?=0
 LUA_VERSION?=5.4.3
 USE_LUA?=0
+AWSLC_VERSION?=1.66.1
+USE_AWSLC?=0
 USE_PROMETHEUS?=0
 CPU?=0
 VERSION=$(shell curl -s http://git.haproxy.org/git/haproxy-${MAINVERSION}.git/refs/tags/ | sed -n 's:.*>\(.*\)</a>.*:\1:p' | sed 's/^.//' | sort -rV | head -1)
@@ -12,7 +14,12 @@ ifeq ("${VERSION}","./")
 endif
 RELEASE?=1
 EXTRA_CFLAGS?=0
-PREREQ:=pcre-devel make gcc openssl-devel rpm-build systemd-devel curl sed zlib-devel
+PREREQ:=pcre-devel make gcc rpm-build systemd-devel curl sed zlib-devel
+ifeq ($(USE_AWSLC),1)
+	PREREQ += cmake wget g++
+else
+	PREREQ += openssl-devel
+endif
 ifeq ($(NO_SUDO),1)
 	SUDO=
 else
@@ -96,4 +103,6 @@ build: $(build_stages)
 	--define "_rpmdir %{_topdir}/RPMS" \
 	--define "_srcrpmdir %{_topdir}/SRPMS" \
 	--define "_use_lua ${USE_LUA}" \
-	--define "_use_prometheus ${USE_PROMETHEUS}"
+	--define "_use_prometheus ${USE_PROMETHEUS}" \
+	--define "_use_awslc ${USE_AWSLC}" \
+	--define "_awslc_version ${AWSLC_VERSION}"

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -35,7 +35,13 @@ BuildRequires: pcre-devel
 BuildRequires: zlib-devel
 BuildRequires: make
 BuildRequires: gcc
+%if 0%{?_use_awslc}
+BuildRequires: cmake
+BuildRequires: wget
+BuildRequires: g++
+%else
 BuildRequires: openssl-devel
+%endif
 
 Requires(pre):      shadow-utils
 Requires:           rsyslog
@@ -84,6 +90,10 @@ risking the system's stability.
 %define __perl_requires /bin/true
 
 %build
+%if 0%{?_use_awslc}
+env BUILDSSL_DESTDIR=/usr AWS_LC_VERSION=%{_awslc_version} scripts/build-ssl.sh
+%endif
+
 regparm_opts=
 %ifarch %ix86 x86_64
 regparm_opts="USE_REGPARM=1"
@@ -125,7 +135,13 @@ CPU="generic"
   CPU="%{_cpu}"
 %endif
 
-%{__make} -j$RPM_BUILD_NCPUS %{?_smp_mflags} ${USE_LUA} CPU="${CPU}" TARGET="linux-glibc" ${systemd_opts} ${pcre_opts} USE_OPENSSL=1 USE_ZLIB=1 ${regparm_opts} ADDINC="$CFLAGS" USE_LINUX_TPROXY=1 USE_THREAD=1 USE_TFO=${USE_TFO} USE_NS=${USE_NS} ${USE_PROMEX} ADDLIB="%{__global_ldflags}"
+%if 0%{?_use_awslc}
+OPENSSL_ARGS="USE_OPENSSL_AWSLC=1 SSL_LIB=/usr/lib SSL_INC=/usr/include"
+%else
+OPENSSL_ARGS="USE_OPENSSL=1"
+%endif
+
+%{__make} -j$RPM_BUILD_NCPUS %{?_smp_mflags} ${USE_LUA} CPU="${CPU}" TARGET="linux-glibc" ${systemd_opts} ${pcre_opts} ${OPENSSL_ARGS} USE_ZLIB=1 ${regparm_opts} ADDINC="$CFLAGS" USE_LINUX_TPROXY=1 USE_THREAD=1 USE_TFO=${USE_TFO} USE_NS=${USE_NS} ${USE_PROMEX} ADDLIB="%{__global_ldflags}"
 
 %{__make} admin/halog/halog OPTIMIZE="%{optflags} %{__global_ldflags}"
 

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -216,16 +216,9 @@ if [ "$1" -ge "1" ]; then
 fi
 %endif
 
-# The file "README" is available < 3.2, while "README.md" is available >= 3.2; if we cannot find either, don't include such file
-%define _readme_file %([ -f README ] && echo README || [ -f README.md ] && echo README.md || echo '')
-
-# The file "doc/architecture.txt" is only available pre 3.2, do not include if the file does not exist
-%define _architecture_txt %([ -f doc/architecture.txt ] && echo doc/architecture.txt || echo '')
-
-%define _doc_files CHANGELOG %{_readme_file} examples/*.cfg %{_architecture_txt} doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
 %files
 %defattr(-,root,root)
-%doc %{?_doc_files}
+%doc CHANGELOG README* examples/*.cfg doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
 %if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
     %license LICENSE
 %endif

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -216,9 +216,13 @@ if [ "$1" -ge "1" ]; then
 fi
 %endif
 
-# The file "README" is available pre 3.2 while "README.md" is available after that; if we cannot find either, don't include such
-# "doc/architecture.txt" is only available pre 3.2, do not include if the file does not exist
-%define _doc_files CHANGELOG %([ -f README ] && echo README || [ -f README.md ] && echo README.md || echo '') examples/*.cfg %([ -f doc/architecture.txt ] && echo doc/architecture.txt || echo '') doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
+# The file "README" is available < 3.2, while "README.md" is available >= 3.2; if we cannot find either, don't include such file
+%define _readme_file %([ -f README ] && echo README || [ -f README.md ] && echo README.md || echo '')
+
+# The file "doc/architecture.txt" is only available pre 3.2, do not include if the file does not exist
+%define _architecture_txt %([ -f doc/architecture.txt ] && echo doc/architecture.txt || echo '')
+
+%define _doc_files CHANGELOG %{_readme_file} examples/*.cfg %{_architecture_txt} doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
 %files
 %defattr(-,root,root)
 %doc %{?_doc_files}

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -216,9 +216,12 @@ if [ "$1" -ge "1" ]; then
 fi
 %endif
 
+# The file "README" is available pre 3.2 while "README.md" is available after that; if we cannot find either, don't include such
+# "doc/architecture.txt" is only available pre 3.2, do not include if the file does not exist
+%define _doc_files CHANGELOG %([ -f README ] && echo README || [ -f README.md ] && echo README.md || echo '') examples/*.cfg %([ -f doc/architecture.txt ] && echo doc/architecture.txt || echo '') doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
 %files
 %defattr(-,root,root)
-%doc CHANGELOG README examples/*.cfg doc/architecture.txt doc/configuration.txt doc/intro.txt doc/management.txt doc/proxy-protocol.txt
+%doc %{?_doc_files}
 %if 0%{?el7} || 0%{?amzn2} || 0%{?amzn2023} || 0%{?el8} || 0%{?el9}
     %license LICENSE
 %endif


### PR DESCRIPTION
This PR completes #74 

# Manual verification
* Installed the HAProxy RPM built from this PR (along with AWS LC):
```
$ make NO_SUDO=1 MAINVERSION=3.3 USE_AWSLC=1
...
$ rpm -i rpmbuild/RPMS/aarch64/haproxy-3.3.1-1.amzn2023.aarch64.rpm --nodeps --force
...
$ haproxy -vv
HAProxy version 3.3.1-9c24c11 2025/12/19 - https://haproxy.org/
Status: stable branch - will stop receiving fixes around Q1 2027.
Known bugs: http://www.haproxy.org/bugs/bugs-3.3.1.html
Running on: Linux 6.17.7-300.fc43.aarch64 #1 SMP PREEMPT_DYNAMIC Sun Nov  2 15:33:04 UTC 2025 aarch64
Build options :
  TARGET  = linux-glibc
  CC      = cc
  CFLAGS  = -O2 -g -fwrapv -fvect-cost-model=very-cheap
  OPTIONS = USE_THREAD=1 USE_LINUX_TPROXY=1 USE_OPENSSL_AWSLC=1 USE_ZLIB=1 USE_TFO=1 USE_NS=1 USE_PCRE=1 USE_PCRE_JIT=1
...
```
* A self-signed certificate generated via the following command, [ref Let's Encrypt](https://letsencrypt.org/docs/certificates-for-localhost/):
```
$ openssl req -x509 -out /tmp/localhost.crt -keyout /tmp/localhost.crt.key \
  -newkey rsa:2048 -nodes -sha256 \
  -subj '/CN=localhost' -extensions EXT -config <( \
   printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
$ openssl x509 -in /tmp/localhost.crt -noout -dates -subject
notBefore=Dec 30 16:17:59 2025 GMT
notAfter=Jan 29 16:17:59 2026 GMT
subject=CN = localhost
```
* Started a dummy HTTP server via `python3 -m http.server`, taking requests on `http://0.0.0.0:8000`
* The following dummy config file is used:
```
global
    maxconn         10000
    stats socket    /var/run/haproxy.stat mode 600 level admin
    log             127.0.0.1:514 local2
    chroot          /var/empty
    pidfile         /var/run/haproxy.pid
    user            haproxy
    group           haproxy
    daemon

frontend public
    bind            *:8443 ssl crt /tmp/localhost.crt
    mode            http
    log             global
    option          httplog
    option          dontlognull
    monitor-uri     /monitoruri
    maxconn         8000
    timeout client  30s

    stats uri       /admin/stats
    default_backend static

backend static
    mode            http
    balance         roundrobin
    option prefer-last-server
    retries         2
    option redispatch
    timeout connect 5s
    timeout server  5s
    server          statsrv1 127.0.0.1:8000
```
* Started HAProxy w/o daemon via `haproxy -db -f haproxy.cfg`
* Verified `https://localhost:8443` SAN via:
```
$ curl -k -vvI https://localhost:8443
16:42:15.061392 [0-x] * Uses proxy env variable NO_PROXY == 'local,169.254/16'
16:42:15.061588 [0-0] * Host localhost:8443 was resolved.
16:42:15.061626 [0-0] * IPv6: ::1
16:42:15.061678 [0-0] * IPv4: 127.0.0.1
16:42:15.061714 [0-0] * [HTTPS-CONNECT] added
16:42:15.061732 [0-0] * [HTTPS-CONNECT] connect, init
16:42:15.061820 [0-0] * [HTTPS-CONNECT] connect, check h21
16:42:15.061873 [0-0] *   Trying [::1]:8443...
16:42:15.062029 [0-0] * [HTTPS-CONNECT] connect -> 0, done=0
16:42:15.062067 [0-0] * [HTTPS-CONNECT] adjust_pollset -> 1 socks
16:42:15.062098 [0-0] * [HTTPS-CONNECT] connect, check h21
16:42:15.062123 [0-0] * connect to ::1 port 8443 from ::1 port 36882 failed: Connection refused
16:42:15.062199 [0-0] *   Trying 127.0.0.1:8443...
16:42:15.062680 [0-0] * [HTTPS-CONNECT] connect -> 0, done=0
16:42:15.062719 [0-0] * [HTTPS-CONNECT] adjust_pollset -> 1 socks
16:42:15.062751 [0-0] * [HTTPS-CONNECT] connect, check h21
16:42:15.064401 [0-0] * ALPN: curl offers h2,http/1.1
16:42:15.064556 [0-0] * TLSv1.3 (OUT), TLS handshake, Client hello (1):
16:42:15.064702 [0-0] * [HTTPS-CONNECT] connect -> 0, done=0
16:42:15.064742 [0-0] * [HTTPS-CONNECT] adjust_pollset -> 1 socks
16:42:15.066724 [0-0] * [HTTPS-CONNECT] connect, check h21
16:42:15.066773 [0-0] * TLSv1.3 (IN), TLS handshake, Server hello (2):
16:42:15.067032 [0-0] * TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
16:42:15.067062 [0-0] * TLSv1.3 (IN), TLS handshake, Certificate (11):
16:42:15.067319 [0-0] * TLSv1.3 (IN), TLS handshake, CERT verify (15):
16:42:15.067424 [0-0] * TLSv1.3 (IN), TLS handshake, Finished (20):
16:42:15.067632 [0-0] * TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
16:42:15.067666 [0-0] * TLSv1.3 (OUT), TLS handshake, Finished (20):
16:42:15.067850 [0-0] * SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / x25519 / RSASSA-PSS
16:42:15.067968 [0-0] * ALPN: server accepted h2
16:42:15.067986 [0-0] * Server certificate:
16:42:15.068005 [0-0] *  subject: CN=localhost
16:42:15.068038 [0-0] *  start date: Dec 30 16:17:59 2025 GMT
16:42:15.068080 [0-0] *  expire date: Jan 29 16:17:59 2026 GMT
16:42:15.068126 [0-0] *  issuer: CN=localhost
16:42:15.068142 [0-0] *  SSL certificate verify result: self-signed certificate (18), continuing anyway.
16:42:15.068160 [0-0] *   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
16:42:15.068217 [0-0] * [HTTPS-CONNECT] connect+handshake h21: 6ms, 1st data: 4ms
16:42:15.068248 [0-0] * [HTTP/2] [0] created h2 session
16:42:15.068268 [0-0] * [HTTP/2] [0] -> FRAME[SETTINGS, len=18]
16:42:15.068283 [0-0] * [HTTP/2] [0] -> FRAME[WINDOW_UPDATE, incr=1048510465]
16:42:15.068313 [0-0] * [HTTP/2] cf_connect() -> 0, 1,
16:42:15.068348 [0-0] * [HTTPS-CONNECT] connect -> 0, done=1
16:42:15.068369 [0-0] * Connected to localhost (127.0.0.1) port 8443
16:42:15.068382 [0-0] * using HTTP/2
16:42:15.068457 [0-0] * [HTTP/2] [1] OPENED stream for https://localhost:8443/
16:42:15.068472 [0-0] * [HTTP/2] [1] [:method: HEAD]
16:42:15.068712 [0-0] * [HTTP/2] [1] [:scheme: https]
16:42:15.068727 [0-0] * [HTTP/2] [1] [:authority: localhost:8443]
16:42:15.068741 [0-0] * [HTTP/2] [1] [:path: /]
16:42:15.068754 [0-0] * [HTTP/2] [1] [user-agent: curl/8.11.1]
16:42:15.068817 [0-0] * [HTTP/2] [1] [accept: */*]
16:42:15.068893 [0-0] * [HTTP/2] [1] submit -> 77, 0
16:42:15.069095 [0-0] * [HTTP/2] [1] -> FRAME[HEADERS, len=35, hend=1, eos=1]
16:42:15.069206 [0-0] * [HTTP/2] [0] egress: wrote 108 bytes
16:42:15.069233 [0-0] * [HTTP/2] [1] cf_send(len=77) -> 77, 0, eos=1, h2 windows 65535-65535 (stream-conn), buffers 0-0 (stream-conn)
16:42:15.069246 [0-0] > HEAD / HTTP/2
16:42:15.069246 [0-0] > Host: localhost:8443
16:42:15.069246 [0-0] > User-Agent: curl/8.11.1
16:42:15.069246 [0-0] > Accept: */*
16:42:15.069246 [0-0] >
16:42:15.069325 [0-0] * [HTTP/2] [0] progress ingress: done
16:42:15.069371 [0-0] * [HTTP/2] [1] cf_recv(len=102400) -> -1 81, window=0/65535, connection 1048576000/1048576000
16:42:15.069388 [0-0] * Request completely sent off
16:42:15.069708 [0-0] * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
16:42:15.069874 [0-0] * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
16:42:15.069946 [0-0] * [HTTP/2] [0] ingress: read 36 bytes
16:42:15.069987 [0-0] * [HTTP/2] [0] <- FRAME[SETTINGS, len=18]
16:42:15.070012 [0-0] * [HTTP/2] [0] MAX_CONCURRENT_STREAMS: 100
16:42:15.070057 [0-0] * [HTTP/2] [0] ENABLE_PUSH: TRUE
16:42:15.070096 [0-0] * [HTTP/2] [0] <- FRAME[SETTINGS, ack=1]
16:42:15.070108 [0-0] * [HTTP/2] [0] progress ingress: inbufg=0
16:42:15.070123 [0-0] * [HTTP/2] [0] progress ingress: done
16:42:15.070300 [0-0] * [HTTP/2] [0] -> FRAME[SETTINGS, ack=1]
16:42:15.070424 [0-0] * [HTTP/2] [0] egress: wrote 9 bytes
16:42:15.070451 [0-0] * [HTTP/2] [1] cf_recv(len=102400) -> -1 81, window=0/65536, connection 1048576000/1048576000
16:42:15.075187 [0-0] * [HTTP/2] [0] ingress: read 103 bytes
16:42:15.075225 [0-0] < HTTP/2 200
HTTP/2 200
16:42:15.075243 [0-0] * [HTTP/2] [1] local window update by 10420224
16:42:15.075288 [0-0] * [HTTP/2] [1] status: HTTP/2 200
16:42:15.075333 [0-0] < server: SimpleHTTP/0.6 Python/3.9.25
server: SimpleHTTP/0.6 Python/3.9.25
16:42:15.075347 [0-0] * [HTTP/2] [1] header: server: SimpleHTTP/0.6 Python/3.9.25
16:42:15.075359 [0-0] < date: Tue, 30 Dec 2025 16:42:15 GMT
date: Tue, 30 Dec 2025 16:42:15 GMT
16:42:15.075371 [0-0] * [HTTP/2] [1] header: date: Tue, 30 Dec 2025 16:42:15 GMT
16:42:15.075383 [0-0] < content-type: text/html; charset=utf-8
content-type: text/html; charset=utf-8
16:42:15.075395 [0-0] * [HTTP/2] [1] header: content-type: text/html; charset=utf-8
16:42:15.075430 [0-0] < content-length: 1011
content-length: 1011
16:42:15.075613 [0-0] * [HTTP/2] [1] header: content-length: 1011
16:42:15.075628 [0-0] * [HTTP/2] [1] <- FRAME[HEADERS, len=94, hend=1, eos=1]
16:42:15.075655 [0-0] <

16:42:15.075685 [0-0] * [HTTP/2] [1] DRAIN select_bits=1
16:42:15.075700 [0-0] * [HTTP/2] [1] CLOSED
16:42:15.075711 [0-0] * [HTTP/2] [1] DRAIN select_bits=1
16:42:15.075796 [0-0] * [HTTP/2] [0] progress ingress: inbufg=0
16:42:15.075810 [0-0] * [HTTP/2] [1] DRAIN select_bits=1
16:42:15.075820 [0-0] * [HTTP/2] [0] progress ingress: done
16:42:15.075833 [0-0] * [HTTP/2] [1] returning CLOSE
16:42:15.075858 [0-0] * [HTTP/2] handle_stream_close -> 0, 0
16:42:15.075870 [0-0] * [HTTP/2] [1] cf_recv(len=102400) -> 0 0, window=-1/-1, connection 1048576000/1048576000
16:42:15.075940 [0-0] * Connection #0 to host localhost left intact
```

# Current limitations:
* When building AWS LC, it will override `openssl` if installed, so better build this in a container
* Source of AWS LC will be stored under `/tmp/download-cache`, it's not cleaned up after building RPM, we can add logic to clean them up but if we run things in containers, we don't need to bother
* Amazon Linux 2 is not supported: we need to install `cmake3` rather than `cmake` to make things work. I am lazy, and this OS is going out of support soon, so probably won't do this for the sake of keeping it alive
* The compiled binary does not have AWS LC statically linked, so when user install the valilla `openssl`, it makes no sense. Maybe we should add a `-awslc` suffix to let user know RPM is complied against AWS LC?
* With AWS LC built and installed, it does not provide `libssl.so` info to RPM, when installing built RPM, we will get 
```
bash-5.2# rpm -i rpmbuild/RPMS/x86_64/haproxy-3.3.1-1.amzn2023.x86_64.rpm
error: Failed dependencies:
	libcrypto.so()(64bit) is needed by haproxy-3.3.1-1.amzn2023.x86_64
	libssl.so()(64bit) is needed by haproxy-3.3.1-1.amzn2023.x86_64
```

But with 
```
bash-5.2# rpm -i rpmbuild/RPMS/x86_64/haproxy-3.3.1-1.amzn2023.x86_64.rpm --nodeps
....
bash-5.2# /usr/sbin/haproxy -vv
HAProxy version 3.3.1-9c24c11 2025/12/19 - https://haproxy.org/
Status: stable branch - will stop receiving fixes around Q1 2027.
Known bugs: http://www.haproxy.org/bugs/bugs-3.3.1.html
Running on: Linux 6.17.7-300.fc43.aarch64 #1 SMP PREEMPT_DYNAMIC Sun Nov  2 15:33:04 UTC 2025 x86_64
Build options :
  TARGET  = linux-glibc
  CC      = cc
  CFLAGS  = -O2 -g -fwrapv -fvect-cost-model=very-cheap
  OPTIONS = USE_THREAD=1 USE_LINUX_TPROXY=1 USE_OPENSSL_AWSLC=1 USE_ZLIB=1 USE_TFO=1 USE_NS=1 USE_PCRE=1 USE_PCRE_JIT=1
  DEBUG   =

Feature list : -51DEGREES +ACCEPT4 +BACKTRACE -CLOSEFROM +CPU_AFFINITY +CRYPT_H -DEVICEATLAS +DL -ECH -ENGINE +EPOLL -EVPORTS +GETADDRINFO -KQUEUE +KTLS -LIBATOMIC +LIBCRYPT +LINUX_CAP +LINUX_SPLICE +LINUX_TPROXY -LUA -MATH -MEMORY_PROFILING +NETFILTER +NS -OBSOLETE_LINKER +OPENSSL +OPENSSL_AWSLC -OPENSSL_WOLFSSL -OT +PCRE -PCRE2 -PCRE2_JIT +PCRE_JIT +POLL +PRCTL -PROCCTL -PROMEX -PTHREAD_EMULATION -QUIC -QUIC_OPENSSL_COMPAT +RT +SHM_OPEN -SLZ +SSL -STATIC_PCRE -STATIC_PCRE2 +TFO +THREAD +THREAD_DUMP +TPROXY -WURFL +ZLIB +ACME

Default settings :
  bufsize = 16384, maxrewrite = 1024, maxpollevents = 200

Built with multi-threading support (MAX_TGROUPS=32, MAX_THREADS=1024, default=12).
Built with SSL library version : OpenSSL 1.1.1 (compatible; AWS-LC 1.66.1)
Running on SSL library version : AWS-LC 1.66.1
SSL library supports TLS extensions : yes
SSL library supports SNI : yes
SSL library FIPS mode : no
SSL library supports : TLSv1.0 TLSv1.1 TLSv1.2 TLSv1.3
Built with network namespace support.
Built with zlib version : 1.2.11
Running on zlib version : 1.2.11
Compression algorithms supported : identity("identity"), deflate("deflate"), raw-deflate("deflate"), gzip("gzip")
Built with transparent proxy support using: IP_TRANSPARENT IPV6_TRANSPARENT IP_FREEBIND
Built with PCRE version : 8.44 2020-02-12
Running on PCRE version : 8.44 2020-02-12
PCRE library supports JIT : yes
Encrypted password support via crypt(3): yes
Built with gcc compiler version 11.5.0 20240719 (Red Hat 11.5.0-5)

Available polling systems :
      epoll : pref=300,  test result OK
       poll : pref=200,  test result OK
     select : pref=150,  test result OK
Total: 3 (3 usable), will use epoll.

Available multiplexer protocols :
(protocols marked as <default> cannot be specified using 'proto' keyword)
         h2 : mode=HTTP  side=FE|BE  mux=H2    flags=HTX|HOL_RISK|NO_UPG
         h1 : mode=HTTP  side=FE|BE  mux=H1    flags=HTX|NO_UPG
  <default> : mode=HTTP  side=FE|BE  mux=H1    flags=HTX
       fcgi : mode=HTTP  side=BE     mux=FCGI  flags=HTX|HOL_RISK|NO_UPG
       spop : mode=SPOP  side=BE     mux=SPOP  flags=HOL_RISK|NO_UPG
  <default> : mode=SPOP  side=BE     mux=SPOP  flags=HOL_RISK|NO_UPG
       none : mode=TCP   side=FE|BE  mux=PASS  flags=NO_UPG
  <default> : mode=TCP   side=FE|BE  mux=PASS  flags=

Available services : none

Available filters :
	[BWLIM] bwlim-in
	[BWLIM] bwlim-out
	[CACHE] cache
	[COMP] compression
	[FCGI] fcgi-app
	[SPOE] spoe
	[TRACE] trace
```
We can verify HAProxy is working, but I think this is more to do with AWS LC, less to do with the RPM
