### PR TITLE
Replace all HTTP URLs with HTTPS ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LUA_VERSION?=5.4.3
 USE_LUA?=0
 USE_PROMETHEUS?=0
 CPU?=0
-VERSION=$(shell curl -s http://git.haproxy.org/git/haproxy-${MAINVERSION}.git/refs/tags/ | sed -n 's:.*>\(.*\)</a>.*:\1:p' | sed 's/^.//' | sort -rV | head -1)
+VERSION=$(shell curl -s https://git.haproxy.org/git/haproxy-${MAINVERSION}.git/refs/tags/ | sed -n 's:.*>\(.*\)</a>.*:\1:p' | sed 's/^.//' | sort -rV | head -1)
 ifeq ("${VERSION}","./")
 		VERSION="${MAINVERSION}.0"
 endif
@@ -48,7 +48,7 @@ clean:
 	mkdir -p ./rpmbuild/SPECS/ ./rpmbuild/SOURCES/ ./rpmbuild/RPMS/ ./rpmbuild/SRPMS/
 
 download-upstream:
-	curl -o ./SOURCES/haproxy-${VERSION}.tar.gz http://www.haproxy.org/download/${MAINVERSION}/src/haproxy-${VERSION}.tar.gz
+	curl -o ./SOURCES/haproxy-${VERSION}.tar.gz https://www.haproxy.org/download/${MAINVERSION}/src/haproxy-${VERSION}.tar.gz
 
 build_lua:
 	rpm -q readline-devel || $(SUDO) yum install -y readline-devel

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -18,8 +18,8 @@ Version: %{version}
 Release: %{release}%{?dist}
 License: GPLv2+
 Group: System Environment/Daemons
-URL: http://www.haproxy.org/
-Source0: http://www.haproxy.org/download/%{mainversion}/src/%{name}-%{version}.tar.gz
+URL: https://www.haproxy.org/
+Source0: https://www.haproxy.org/download/%{mainversion}/src/%{name}-%{version}.tar.gz
 Source1: %{name}.cfg
 %if 0%{?el6} || 0%{?amzn1}
 Source2: %{name}.init


### PR DESCRIPTION
Fixes #79 

# Verification
Verified with a dummy build with the following command
```
$ podman run -it --rm -v $PWD:/root -w /root --name al2023 amazonlinux:2023 bash
bash-5.2# yum install -y make
...
Installed:
  gc-8.0.4-5.amzn2023.0.2.aarch64       guile22-2.2.7-2.amzn2023.0.3.aarch64       libtool-ltdl-2.4.7-1.amzn2023.0.3.aarch64       make-1:4.3-5.amzn2023.0.2.aarch64

Complete!
bash-5.2# make NO_SUDO=1 MAINVERSION=3.0
# Check if the prereqs are there before trying to sudo 
...
Wrote: /root/rpmbuild/RPMS/aarch64/haproxy-3.0.14-1.amzn2023.aarch64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.F1putG
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd haproxy-3.0.14
+ '[' /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64 '!=' / ']'
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/haproxy-3.0.14-1.amzn2023.aarch64
+ RPM_EC=0
++ jobs -p
+ exit 0
```